### PR TITLE
Create version 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.10.0 (2024-07-31)
+- fix: "ensure" => "latest" now works properly with Homebrew 4
+- fix: add ability to install Homebrew on arm64
+- compatibility: support Rosetta 2
+- compatibility: mark only compatiable with Puppet 7
+- meta: add direnv setup
+- meta: clean up rubocop and puppet-lint issues
+
 ## 1.9.1 (2021-09-23)
 - internal: fixup overly-narrow stdlib version pin
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,16 @@
 {
-  "name": "thekevjames-homebrew",
-  "version": "1.9.1",
-  "author": "thekevjames",
+  "name": "uber-puppet-homebrew",
+  "version": "1.10.0",
+  "author": "uber",
   "summary": "Homebrew (+brewcask! +taps!) package installer and provider",
   "license": "Apache-2.0",
-  "source": "https://github.com/TheKevJames/puppet-homebrew",
-  "project_page": "https://github.com/TheKevJames/puppet-homebrew",
-  "issues_url": "https://github.com/TheKevJames/puppet-homebrew/issues",
+  "source": "https://github.com/uber/puppet-homebrew",
+  "project_page": "https://github.com/uber/puppet-homebrew",
+  "issues_url": "https://github.com/uber/puppet-homebrew/issues",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.2.0 < 7.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.7.1",


### PR DESCRIPTION
Since we've forked and added some fixes, this PR is intended to reduce confusion by:

 - Explicitly enumerating the fixes since 1.9.1
 - Change the Puppet Forge config to unique values for Uber's fork. However, there are no current plans to upload to Puppet Forge.